### PR TITLE
Date parsing workaround

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -1,0 +1,11 @@
+// Simple workaround for older JavaScript engines that
+// do not understand the One True Date Format.
+// This doesn't totally mimic new Date(), just string parsing.
+exports.newDate = function (rfc3399) {
+    var temp = Date.parse(rfc3399);
+    if (isNaN(temp)) {
+      // this technique is borrowed from jquery.couch.app.util's $.prettyDate
+      temp = rfc3399.replace(/-/g,"/").replace("T", " ").replace("Z", " +0000").replace(/(\d*\:\d*:\d*)\.\d*/g,"$1");
+    }
+    return new Date(temp);
+}

--- a/lists/comments.js
+++ b/lists/comments.js
@@ -4,6 +4,7 @@ function(head, req) {
   var List = require("vendor/couchapp/lib/list");
   var path = require("vendor/couchapp/lib/path").init(req);
   var Atom = require("vendor/couchapp/lib/atom");
+  var newDate = require("lib/date").newDate;
 
   var indexPath = path.list('index','recent-posts',{descending:true, limit:10});
   var feedPath = path.list('index','recent-posts',{descending:true, limit:10, format:"atom"});
@@ -21,7 +22,7 @@ function(head, req) {
     
     // generate the feed header
     var feedHeader = Atom.header({
-      updated : (row ? new Date(row.value.created_at) : new Date()),
+      updated : (row ? newDate(row.value.created_at) : new Date()),
       title : ddoc.blog.title + " comments",
       feed_id : path.absolute(indexPath),
       feed_link : path.absolute(commentsFeed)
@@ -40,7 +41,7 @@ function(head, req) {
           entry_id : path.absolute('/'+encodeURIComponent(req.info.db_name)+'/'+encodeURIComponent(row.id)),
           title : "comment on "+v.post_id,
           content : markdown.encode(Mustache.escape(v.comment)),
-          updated : new Date(v.created_at),
+          updated : newDate(v.created_at),
           author : v.commenter.nickname || v.commenter.name,
           alternate : path.absolute(path.list('post','post-page', {startkey:[v.post_id]}))
         });

--- a/lists/index.js
+++ b/lists/index.js
@@ -4,7 +4,8 @@ function(head, req) {
   var List = require("vendor/couchapp/lib/list");
   var path = require("vendor/couchapp/lib/path").init(req);
   var Atom = require("vendor/couchapp/lib/atom");
-
+  var newDate = require("lib/date").newDate;
+  
   var indexPath = path.list('index','recent-posts',{descending:true, limit:10});
   var feedPath = path.list('index','recent-posts',{descending:true, limit:10, format:"atom"});
   var commentsFeed = path.list('comments','comments',{descending:true, limit:10, format:"atom"});
@@ -74,7 +75,7 @@ function(head, req) {
     
     // generate the feed header
     var feedHeader = Atom.header({
-      updated : (row ? new Date(row.value.created_at) : new Date()),
+      updated : (row ? newDate(row.value.created_at) : new Date()),
       title : ddoc.blog.title,
       feed_id : path.absolute(indexPath),
       feed_link : path.absolute(feedPath),
@@ -98,7 +99,7 @@ function(head, req) {
           entry_id : path.absolute('/'+encodeURIComponent(req.info.db_name)+'/'+encodeURIComponent(row.id)),
           title : row.value.title,
           content : html,
-          updated : new Date(row.value.created_at),
+          updated : newDate(row.value.created_at),
           author : row.value.author,
           alternate : path.absolute(path.show('post', row.id))
         });

--- a/views/comments/map.js
+++ b/views/comments/map.js
@@ -5,6 +5,6 @@ function(doc) {
       // todo normalize this schema-ness
       doc.commenter.gravatar = hex_md5(doc.commenter.email);      
     }
-    emit(new Date(doc.created_at), doc);
+    emit(doc.created_at, doc);
   }
 };

--- a/views/recent-posts/map.js
+++ b/views/recent-posts/map.js
@@ -1,5 +1,5 @@
 function(doc) {
   if (doc.type == "post") {
-    emit(new Date(doc.created_at), doc);
+    emit(doc.created_at, doc);
   }
 };


### PR DESCRIPTION
Sofa doesn't generate proper feeds or view indexes on builds of CouchDB that use an out-of-date (pun intended) version of SpiderMonkey (including the official CouchDBX 1.0.1.1 currently available).
