### PR TITLE
Tcaddy

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -16,7 +16,25 @@ exports.init = function(newDoc, oldDoc, userCtx, secObj) {
   }
   
   v.isAdmin = function() {
-    return userCtx.roles.indexOf('_admin') != -1
+    return ((userCtx.roles.indexOf('_admin') != -1) || v.isDbAdmin())
+  };
+  
+  v.isDbAdmin = function() {
+    if (secObj && secObj.admins) {
+      if (secObj.admins.names) {
+        if (secObj.admins.names.indexOf(userCtx.name) != -1) {
+          return true;
+        }
+      }
+      if (secObj.admins.roles) {
+        for (var i=0, l=secObj.admins.roles.length; i<l; i++) {
+          if (userCtx.roles.indexOf(secObj.admins.roles[i]) != -1) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
   };
 
   v.require = function() {


### PR DESCRIPTION
In futon, each database has a 'Security...' setting described as:
Each database contains lists of admins and readers. Admins and readers are each defined by names and roles, which are lists of strings.
Admins:  Database admins can update design documents and edit the readers list.
Names: []  
Roles: []

The v.isAdmin() function in lib/validate.js doesn't take into account these database-specific admin settings.  So I wrote another function called v.isDbAdmin() to test for that and modified v.isAdmin() to return true if the v.isDbAdmin() function returns true.
