### PR TITLE
Display quotation marks in existing titles and tags

### DIFF
--- a/shows/edit.js
+++ b/shows/edit.js
@@ -21,9 +21,9 @@ function(doc, req) {
   
   if (doc) {
     data.doc = JSON.stringify(doc);
-    data.title = doc.title;
+    data.title = doc.title.replace(/"/g,"&quot;");
     data.body = doc.body;
-    data.tags = doc.tags.join(", ");
+    data.tags = doc.tags.join(", ").replace(/"/g,"&quot;");
   } else {
     data.doc = JSON.stringify({
       type : "post",

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -12,7 +12,7 @@
     <form id="new-post" action="new.html" method="post">
       <h1>{{pageTitle}}</h1>
         <p><label>Title</label>
-          <input type="text" size="50" name="title" value="{{title}}"></p>
+          <input type="text" size="50" name="title" value="{{{title}}}"></p>
       <p><label for="body">Body</label>
       <textarea name="body" rows="28" cols="80">{{body}}</textarea></p>
       <p>

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -17,7 +17,7 @@
       <textarea name="body" rows="28" cols="80">{{body}}</textarea></p>
       <p>
         <label for="tags">Click tags to add them. (split by ',')</label>
-        <input size="50" type="text" name="tags" value="{{tags}}">
+        <input size="50" type="text" name="tags" value="{{{tags}}}">
       </p>
       <p>
         <input id="preview" type="button" value="Preview"/>


### PR DESCRIPTION
Quotation marks were previously put unescaped into form element value attributes, which allowed for html injection and was also rather annoying.
